### PR TITLE
Find hidden emails

### DIFF
--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -32,6 +32,12 @@ class TestDeobfuscate(unittest.TestCase):
         atob = 'atob(\'bWFpbHRvOmVtYWlsQGV4YW1wbGUuY29t\')'
         self.assertEqual(deobfuscate_html(atob), 'mailto:email@example.com')
 
+class TestHidden(unittest.TestCase):
+    def test_hidden(self):
+        self.assertEqual(
+            extract_emails("foo johnsmith (at) yahoo (dot) com bar"),
+            ["johnsmith@yahoo.com"]
+        )
 
 class TestScraping(unittest.TestCase):
     def test_basic(self):


### PR DESCRIPTION
Finds emails of the format (and similar)
```
johnsmith (at) gmail (dot) com
```

The most practical way to approach automating email scraping would be to use headless selenium, since a lot of sites now use Javascript to hide emails.